### PR TITLE
use fit instead of setCenter

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
           </div>
         </div>
         <div class="col">
-          <button id="map2-center" class="btn btn-dark mb-2" type="button">Obtenir le centre</button>
+          <button id="map2-center" class="btn btn-dark mb-2" type="button">Obtenir le centre des objets dessinés</button>
           <label class="mb-2"><span class="badge" id="getcoorde2"></span> <span class="badge badge-secondary"
               id="getcoordn2"></span></label>
         </div>
@@ -217,7 +217,7 @@
       <button id="map5-upd-marker" class="btn btn-info">Mettre à jour</button>
       <button class="btn btn-danger" onclick="map4.removeMarker()">Supprimer</button>
       <button id="map5-recenter" class="btn btn-dark">Recentrer la carte</button>
-      <button id="map5-get-center" class="btn btn-dark">Obtenir le centre</button>
+      <button id="map5-get-center" class="btn btn-dark">Obtenir le centre des objets dessinés</button>
       <label><span class="badge" id="getcoorde"></span> <span class="badge badge-secondary"
           id="getcoordn"></span></label>
     </div>

--- a/js/sitnlayers.js
+++ b/js/sitnlayers.js
@@ -434,8 +434,8 @@
     sitnLayers.recenterMap = function (coordinates, zoomLevel) {
       if (_map) {
         const view = _map.getView();
-        view.setCenter(coordinates);
-        view.setZoom(zoomLevel);
+        const point = new ol.geom.Point(coordinates);
+        view.fit(point, { maxZoom: zoomLevel });
       }
     };
 


### PR DESCRIPTION
`setCenter()` and `setZoom()` doesn't behave the same way as `fit()` on a `View`. For some reason, after a `setZoom()`, using mouse drag to pan the map was causing the layer to disappear.